### PR TITLE
fix: Typo3CoreVersionService.php

### DIFF
--- a/Classes/Service/Typo3CoreVersionService.php
+++ b/Classes/Service/Typo3CoreVersionService.php
@@ -193,6 +193,6 @@ class Typo3CoreVersionService
     {
         $url = 'major/' . $majorVersion->getVersion() . '/release/latest/security';
         $result = $this->fetchFromRemote($url);
-        return CoreRelease::fromApiResponse($result);
+        return $result ? CoreRelease::fromApiResponse($result) : null;
     }
 }


### PR DESCRIPTION
Hi @schams-net ,

during sprint releases of TYPO3 v13 I noticed that there is no security release for some, which results in an exception we could handle.

just check if a security release is available or return null

