### PR TITLE
Update MajorRelease.php

### DIFF
--- a/Classes/CoreVersion/MajorRelease.php
+++ b/Classes/CoreVersion/MajorRelease.php
@@ -126,7 +126,7 @@ class MajorRelease
         } else {
             foreach ($this->coreReleases as $coreRelease) {
                 $versionString = $coreRelease->getVersion();
-                if (version_compare($versionString, $this->getLts()) === -1) {
+                if (version_compare($versionString, $this->getLts() ?? '') === -1) {
                     if (mb_substr_count($versionString, '.') == 2) {
                         $insecureVersions[] = mb_substr($versionString, 0, mb_strrpos($versionString, '.')) . '.x';
                     }


### PR DESCRIPTION
Hi @schams-net ,

and another one, because we have a security issue in TYPO3 v 13.0.0 ;-)

If the MajorReleases does not provide informations about lts the version_comparisson fails during generation of cfg string