### PR TITLE
feat: Add support for TYPO3 v13 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for insecure TYPO3 instances. See https://schams.net/nagios for further details.
 
 ## System Requirements
 
-* TYPO3 version 12 LTS
+* TYPO3 version 12 LTS or 13 LTS
 * PHP version 8.x
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
 	"description": "Generates a list of insecure extensions for EXT:nagios based on the extension list in the current TYPO3 instance.",
 	"type": "typo3-cms-extension",
 	"require": {
-		"typo3/cms-core": "^12",
-		"typo3/cms-frontend":"^12",
-		"typo3/cms-backend": "^12",
-		"typo3/cms-scheduler": "^12",
-		"typo3/cms-extensionmanager": "^12",
-		"typo3/cms-setup": "^12",
-		"typo3/cms-extbase": "^12",
-		"typo3/cms-fluid": "^12"
+		"typo3/cms-core": "^12 || ^13",
+		"typo3/cms-frontend":"^12 || ^13",
+		"typo3/cms-backend": "^12 || ^13",
+		"typo3/cms-scheduler": "^12 || ^13",
+		"typo3/cms-extensionmanager": "^12 || ^13",
+		"typo3/cms-setup": "^12 || ^13",
+		"typo3/cms-extbase": "^12 || ^13",
+		"typo3/cms-fluid": "^12 || ^13"
 	},
 	"require-dev": {
 		"ergebnis/composer-normalize": "*",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'php' => '8.1.0-8.4.99',
-            'typo3' => '12.4.0-12.4.99',
+            'typo3' => '12.4.0-13.4.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
- Updated system requirements in `README.md`.
- Extended compatibility in `ext_emconf.php` and `composer.json` to support TYPO3 v13.

Hi @schams-net ,
we are upgrading or system to TYPO3 13 finally and adjusted the constraints of the extension.

On our integration system it seems to work with PHP8.4 and TYPO3 13.

Regards and happy 2026
Markus